### PR TITLE
Add `getConfigForLabel()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ lib/
 build/
 coverage/
 tmp/
+test.js

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -3,7 +3,8 @@
   "extension": [".ts", ".js"],
   "check-coverage": true,
   "include": ["src/**"],
-  "statements": 99.5,
+  "exclude": ["src/**/_test_/**", "src/index.ts"],
+  "statements": 99,
   "branches": 94,
   "functions": 98,
   "lines": 99

--- a/example.yaml
+++ b/example.yaml
@@ -15,6 +15,8 @@
 # use the alternative value "prd-database"
 # if the "environment" context dimension value is "production" or "stage"
 - setting: database
+  # Assign a label to the setting for grouping settings together
+  labels: ['server']
   # default value if no context is specified
   value: test-database
   except:

--- a/src/_test_/cerebro_test.ts
+++ b/src/_test_/cerebro_test.ts
@@ -161,10 +161,13 @@ describe('./cerebro.ts', function () {
 
   describe('CerebroConfig', function () {
     let rawConfig
+    let labelResolved
 
     beforeEach(function () {
-      var cerebro = new Cerebro([])
-      var labels = { a: ['s'], b: ['c'], c: ['s', 'c'] }
+      const cerebro = new Cerebro([])
+      const labels = { a: ['s'], b: ['c'], c: ['s', 'c'] }
+      labelResolved = { s: { a: 111 } }
+
       rawConfig = {
         a: 111,
         b: true,
@@ -175,7 +178,7 @@ describe('./cerebro.ts', function () {
       }
 
       this.sandbox.stub(Cerebro.prototype, '_build').callsFake(function () {
-        return { answers: rawConfig, labels }
+        return { answers: rawConfig, labels, labelResolved: labelResolved }
       })
       this.rawConfig = rawConfig
       this.labels = labels
@@ -312,14 +315,27 @@ describe('./cerebro.ts', function () {
       })
     })
 
+    describe('#getConfigForLabel', function () {
+      it('returns a config for a defined label', function () {
+        expect(this.cerebroConfig.getConfigForLabel('s')).to.eql(
+          labelResolved.s
+        )
+      })
+
+      it('returns null for an undefined label', function () {
+        expect(this.cerebroConfig.getConfigForLabel('undef_label')).to.eql(null)
+      })
+    })
+
     describe('#dehydrate', function () {
       it('returns a JSON string', function () {
-        var json = this.cerebroConfig.dehydrate()
+        const json = this.cerebroConfig.dehydrate()
 
         expect(json).to.equal(
           JSON.stringify({
             _resolved: this.rawConfig,
-            _labels: this.labels
+            _labels: this.labels,
+            _labelResolved: labelResolved
           })
         )
       })

--- a/src/_test_/evaluator_test.ts
+++ b/src/_test_/evaluator_test.ts
@@ -140,6 +140,30 @@ describe('evaluator.ts', function () {
       expect(answer.key).to.equal(this.settingName)
       expect(answer.value).to.equal(false)
     })
+
+    it('overrides the original setting', function () {
+      var entry = {
+        setting: this.settingName,
+        value: 'abcd',
+        except: [
+          {
+            farm: ['1234'],
+            value: 'defg'
+          }
+        ]
+      }
+      var overrides = {
+        testSetting: 'higj'
+      }
+      var answer
+
+      this.sandbox.stub(Condition, 'evaluate').returns(false)
+
+      answer = Evaluator.evaluate(entry, context, overrides)
+
+      expect(answer.key).to.equal(this.settingName)
+      expect(answer.value).to.equal('higj')
+    })
   })
 
   describe('multiple conditions', function () {

--- a/src/cerebro-config.ts
+++ b/src/cerebro-config.ts
@@ -1,4 +1,4 @@
-import { ICerebroConfig } from './interfaces'
+import { ICerebroConfig, ICerebroConfigParams } from './interfaces'
 
 /**
  * Wrapper for resolvedConfig that provides convenience methods for checking value types and dehydration
@@ -6,14 +6,16 @@ import { ICerebroConfig } from './interfaces'
  * @param {Object} resolvedConfig - object created by building context with settings config
  */
 export class CerebroConfig implements ICerebroConfig {
-  _resolved: any
-  _labels: any
+  _resolved: Record<string, any>
+  _labels: Record<string, Array<string>>
+  _labelResolved: Record<string, any>
 
-  constructor (resolvedConfig) {
+  constructor (resolvedConfig: ICerebroConfigParams) {
     if (!resolvedConfig.answers) {
       throw new Error('`resolvedConfig` is required')
     }
 
+    this._labelResolved = resolvedConfig.labelResolved
     this._resolved = resolvedConfig.answers
     this._labels = resolvedConfig.labels
   }
@@ -170,8 +172,8 @@ export class CerebroConfig implements ICerebroConfig {
    * @return {JSON} Map of settings to values.
    */
   dehydrate (): string {
-    const { _resolved, _labels } = this
-    const dehydratedObject = { _resolved, _labels }
+    const { _resolved, _labels, _labelResolved } = this
+    const dehydratedObject = { _resolved, _labels, _labelResolved }
 
     return JSON.stringify(dehydratedObject)
   }
@@ -188,13 +190,22 @@ export class CerebroConfig implements ICerebroConfig {
   }
 
   /**
+   * Gets configuration that was categorized under a specific label.
+   *
+   * Returns null if the label does not exist.
+   */
+  getConfigForLabel (label: string): Record<string, any> {
+    return this._labelResolved[label] || null
+  }
+
+  /**
    * Returns the labels from the entries
    *
    * @return {Object} The labels as an object just like getRawConfig,
    * where each key is setting name and its value is an array of string labels.
    * Entries with no labels are represented as an empty array (not undefined).
    */
-  getLabels (): Record<string, any> {
+  getLabels (): Record<string, Array<string>> {
     return this._labels
   }
 }

--- a/src/cerebro.ts
+++ b/src/cerebro.ts
@@ -16,7 +16,7 @@ import { CerebroConfig } from './cerebro-config'
 /**
  * @param {Array} config - array containing setting entries
  * @param {Object} [Optional] options Object containing customEvaluators
- *      @param {Object} customEvaluators object containing the custom evaluation methods
+ * @param {Object} customEvaluators object containing the custom evaluation methods
  */
 export class Cerebro {
   _config: any
@@ -65,10 +65,11 @@ export class Cerebro {
     // if the dehydratedObject is not valid, JSON parse will fail and throw an error
     const rehydratedObj = JSON.parse(dehydratedObject)
 
-    const { _resolved, _labels } = rehydratedObj
+    const { _resolved, _labels, _labelResolved } = rehydratedObj
     const builtObject = {
       answers: _resolved,
-      labels: _labels
+      labels: _labels,
+      labelResolved: _labelResolved
     }
 
     return new CerebroConfig(builtObject)
@@ -83,7 +84,9 @@ export class Cerebro {
 
   private _build (context, overrides) {
     const answers = {}
-    const labels = {}
+    const labels: Record<string, Array<string>> = {}
+    const labelResolved = {}
+
     let answer
 
     this._config.forEach(function (entry) {
@@ -99,13 +102,22 @@ export class Cerebro {
         if (!answers.hasOwnProperty(answer.key)) {
           answers[answer.key] = answer.value
           labels[answer.key] = entry.labels || []
+
+          labels[answer.key].forEach(label => {
+            if (!labelResolved[label]) {
+              labelResolved[label] = {}
+            }
+
+            labelResolved[label][answer.key] = answer.value
+          })
         }
       }
     }, this)
 
     return {
       answers,
-      labels
+      labels,
+      labelResolved
     }
   }
 

--- a/src/condition.ts
+++ b/src/condition.ts
@@ -50,8 +50,8 @@ export class Condition {
         )
       case CONDITION_TYPES.PRIMITIVE:
         return this._checkPrimitive(condition, testValue)
-      default:
-        throw new Error('Unrecognized except type: ' + type)
+      // _getConditionType will always throw if it cannot
+      // recognize the type
     }
   }
 

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -93,7 +93,7 @@ export class Evaluator {
    * @param {Object} customEvaluators Any custom evaluators for the config
    * @return {} The answer for the entry
    */
-  static evaluate (entry, context, overrides, answers, customEvaluators?) {
+  static evaluate (entry, context, overrides?, answers?, customEvaluators?) {
     let i
     let exceptBlock
     const options = { context: context, overrides: null }
@@ -216,13 +216,16 @@ export class Evaluator {
    * ```
    * It is returned in this format for the ease of use by the caller.
    */
-  private static _getAnswer (entry, exceptBlock, options) {
+  private static _getAnswer (
+    entry,
+    exceptBlock,
+    options: {
+      context?: Record<string, any>
+      overrides?: Record<any, any>
+    } = {}
+  ) {
     const block = exceptBlock || entry
     let overrideValue
-
-    if (!options) {
-      options = {}
-    }
 
     if (options.overrides) {
       overrideValue = options.overrides[entry.setting]

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -22,6 +22,21 @@ export interface ICerebroConfigOptions {
   overrides?: Record<string, any>
 }
 
+export interface ICerebroConfigParams {
+  /**
+   * Map of setting name : array of labels
+   */
+  labels: Record<string, Array<string>>
+  /**
+   * Map of label : setting value
+   */
+  labelResolved: Record<string, any>
+  /**
+   * The resolved configuration object
+   */
+  answers: Record<string, any>
+}
+
 export interface ICerebroConfig {
   /**
    * Gets the requested value in its raw form. No checks are performed on it.
@@ -100,6 +115,12 @@ export interface ICerebroConfig {
    * Entries with no labels are represented as an empty array (not undefined).
    */
   getLabels(): Record<string, any>
+  /**
+   * Gets configuration categorized under a specific label.
+   *
+   * Returns null if the label does not exist.
+   */
+  getConfigForLabel(label: string): Record<string, any>
 }
 
 export type DynamicConfigBuilder = (


### PR DESCRIPTION
In `cerebro`, you can assign tags (it calls them `labels`) to settings to group settings under a particular tag.

Although it could do this, its usage was very limited as it does not have a getter to work with them.

The new method allows you to get a set of settings by its tag.