### PR TITLE
Add getAssertValue(), Remove type-specific getters

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,11 +199,7 @@ export function middleware((req, res) => {
 
 ## `CerebroConfig` API
 
-Use the API to fetch values from your configuration.
-
-Configuration values are accessed via the `CerebroConfig` API.
-
-You should use the basic getters in your normal workflow.
+Use the API methods to fetch values from your configuration.
 
 ### `getAssertValue(settingName: string) : any`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configurity",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "A production-grade YAML-based configuration system.",
   "author": "Scott Sperling <scsper@yahoo.com>",
   "contributors": [

--- a/src/_test_/cerebro_test.ts
+++ b/src/_test_/cerebro_test.ts
@@ -174,7 +174,10 @@ describe('./cerebro.ts', function () {
         c: { multilevel: [1, 2] },
         d: 12.3,
         e: 'test',
-        asArray: [1, 2]
+        asArray: [1, 2],
+        f: null,
+        g: undefined,
+        h: ''
       }
 
       this.sandbox.stub(Cerebro.prototype, '_build').callsFake(function () {
@@ -203,6 +206,44 @@ describe('./cerebro.ts', function () {
       })
     })
 
+    describe('#getAssertValue', function () {
+      it('returns state value', function () {
+        expect(this.cerebroConfig.getAssertValue('a')).to.equal(111)
+      })
+
+      it('throws an error if the setting is a boolean', function () {
+        expect(
+          function () {
+            this.cerebroConfig.getAssertValue('b')
+          }.bind(this)
+        ).to.throw(/Please use #isEnabled instead./)
+      })
+
+      it('throws an error if the setting is null', function () {
+        expect(
+          function () {
+            this.cerebroConfig.getAssertValue('f')
+          }.bind(this)
+        ).to.throw(/from getAssertValue/)
+      })
+
+      it('throws an error if the setting is undefined', function () {
+        expect(
+          function () {
+            this.cerebroConfig.getAssertValue('g')
+          }.bind(this)
+        ).to.throw(/from getAssertValue/)
+      })
+
+      it('throws an error if the setting is an empty string', function () {
+        expect(
+          function () {
+            this.cerebroConfig.getAssertValue('h')
+          }.bind(this)
+        ).to.throw(/from getAssertValue/)
+      })
+    })
+
     describe('#isEnabled', function () {
       it('does not evaluate if feature is not present', function () {
         expect(this.cerebroConfig.isEnabled('non_existing_feature')).to.be.null
@@ -218,78 +259,6 @@ describe('./cerebro.ts', function () {
             this.cerebroConfig.isEnabled('a')
           }.bind(this)
         ).to.throw(/Please use #getValue instead./)
-      })
-    })
-
-    describe('#getInt', function () {
-      it('does not evaluate if feature is not present', function () {
-        expect(this.cerebroConfig.getInt('non_existing_feature')).to.be.null
-      })
-
-      it('does not evaluate if feature is not a number', function () {
-        expect(this.cerebroConfig.getInt('b')).to.be.null
-      })
-
-      it('returns feature value', function () {
-        expect(this.cerebroConfig.getInt('a')).to.equal(111)
-      })
-    })
-
-    describe('#getFloat', function () {
-      it('does not evaluate if feature is not present', function () {
-        expect(this.cerebroConfig.getFloat('non_existing_feature')).to.be.null
-      })
-
-      it('does not evaluate if feature is not a number', function () {
-        expect(this.cerebroConfig.getFloat('b')).to.be.null
-      })
-
-      it('returns feature value', function () {
-        expect(this.cerebroConfig.getFloat('d')).to.equal(12.3)
-      })
-    })
-
-    describe('#getArray', function () {
-      it('does not evaluate if feature is not present', function () {
-        expect(this.cerebroConfig.getArray('non_existing_feature')).to.be.null
-      })
-
-      it('does not evaluate if feature is not an array', function () {
-        expect(this.cerebroConfig.getArray('d')).to.be.null
-      })
-
-      it('returns feature value', function () {
-        expect(this.cerebroConfig.getArray('asArray')).to.equal(
-          rawConfig.asArray
-        )
-      })
-    })
-
-    describe('#getObject', function () {
-      it('does not evaluate if feature is not present', function () {
-        expect(this.cerebroConfig.getObject('non_existing_feature')).to.be.null
-      })
-
-      it('does not evaluate if feature is not an object', function () {
-        expect(this.cerebroConfig.getObject('b')).to.be.null
-      })
-
-      it('returns feature value', function () {
-        expect(this.cerebroConfig.getObject('c')).to.equal(rawConfig.c)
-      })
-    })
-
-    describe('#getString', function () {
-      it('does not evaluate if feature is not present', function () {
-        expect(this.cerebroConfig.getString('non_existing_feature')).to.be.null
-      })
-
-      it('does not evaluate if feature is not a string', function () {
-        expect(this.cerebroConfig.getString('b')).to.be.null
-      })
-
-      it('returns feature value', function () {
-        expect(this.cerebroConfig.getString('e')).to.equal('test')
       })
     })
 

--- a/src/cerebro-config.ts
+++ b/src/cerebro-config.ts
@@ -49,83 +49,6 @@ export class CerebroConfig implements ICerebroConfig {
   }
 
   /**
-   * Gets the requested value as an object. Returns null if the value does not exist or is not an object.
-   * @param {String} name The name of the setting that you want to value of
-   * @return {Object|null} The value of the setting
-   */
-  getObject<T = any> (name: string): Record<string, T> {
-    const setting = this._resolved[name]
-
-    if (typeof setting === 'undefined' || typeof setting !== 'object') {
-      return null
-    }
-
-    return setting
-  }
-
-  /**
-   * Gets the requested value as a float. Returns null if the value does not exist or is not a number.
-   * @param {String} name The name of the setting that you want to value of
-   * @return {Number|null} The value of the setting
-   */
-  getFloat (name: string): number {
-    const setting = this._resolved[name]
-    const value = parseFloat(setting)
-
-    if (typeof setting === 'undefined' || isNaN(value)) {
-      return null
-    }
-
-    return value
-  }
-
-  /**
-   * Gets the requested value as an integer. Returns null if the value does not exist or is not a number.
-   * @param {String} name The name of the setting that you want to value of
-   * @return {Number|null} The value of the setting
-   */
-  getInt (name: string): number {
-    const setting = this._resolved[name]
-    const value = parseInt(setting, 10)
-
-    if (typeof setting === 'undefined' || isNaN(value)) {
-      return null
-    }
-
-    return value
-  }
-
-  /**
-   * Gets the requested value as an array. Returns null if the value does not exist or is not an array.
-   * @param {String} name The name of the setting that you want to value of
-   * @return {Array|null}
-   */
-  getArray<T = any> (name: string): Array<T> {
-    const setting = this._resolved[name]
-
-    if (typeof setting === 'undefined' || !Array.isArray(setting)) {
-      return null
-    }
-
-    return setting
-  }
-
-  /**
-   * Gets the requested value as a string. Returns null if the value does not exist or is not a string.
-   * @param {String} name The name of the setting that you want to value of
-   * @return {String|null}
-   */
-  getString (name: string): string {
-    const setting = this._resolved[name]
-
-    if (typeof setting === 'undefined' || typeof setting !== 'string') {
-      return null
-    }
-
-    return setting
-  }
-
-  /**
    * Gets the requested value if it is not a Boolean.  Returns null if the value does not exist.
    * Throws an error if the requested value is a Boolean.
    *
@@ -149,6 +72,36 @@ export class CerebroConfig implements ICerebroConfig {
     }
 
     // did not include other types for backwards-compat
+
+    return setting
+  }
+
+  /**
+   * Gets the requested value if it is not a Boolean.
+   * Throws an error if the requested value is a Boolean / empty / null / undefined.
+   *
+   * @param {String} name The name of the setting that you want to value of
+   * @return {!Boolean|*} The value of the setting
+   */
+  getAssertValue<T = any> (name: string): T {
+    const setting = this._resolved[name]
+
+    if (setting === '' || setting === null || typeof setting === 'undefined') {
+      throw new Error(
+        'The requested setting (' +
+          name +
+          ') from getAssertValue is an empty string, null, or undefined.'
+      )
+    }
+
+    if (typeof setting === 'boolean') {
+      throw new Error(
+        'The requested setting (' +
+          name +
+          ') from isEnabled is a boolean.  ' +
+          'Please use #isEnabled instead.'
+      )
+    }
 
     return setting
   }
@@ -199,11 +152,9 @@ export class CerebroConfig implements ICerebroConfig {
   }
 
   /**
-   * Returns the labels from the entries
+   * Returns an object in the form of `{ <setting_name>: <array of labels> }`.
    *
-   * @return {Object} The labels as an object just like getRawConfig,
-   * where each key is setting name and its value is an array of string labels.
-   * Entries with no labels are represented as an empty array (not undefined).
+   * For settings without labels, an empty array is assigned instead.
    */
   getLabels (): Record<string, Array<string>> {
     return this._labels

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -54,36 +54,6 @@ export interface ICerebroConfig {
    */
   isEnabled(name: string): boolean
   /**
-   * Gets the requested value as an object. Returns null if the value does not exist or is not an object.
-   * @param {String} name The name of the setting that you want to value of
-   * @return {Object|null} The value of the setting
-   */
-  getObject<U = any>(name: string): Record<string, U>
-  /**
-   * Gets the requested value as an integer. Returns null if the value does not exist or is not a number.
-   * @param {String} name The name of the setting that you want to value of
-   * @return {Number|null} The value of the setting
-   */
-  getInt(name: string): number
-  /**
-   * Gets the requested value as a float. Returns null if the value does not exist or is not a number.
-   * @param {String} name The name of the setting that you want to value of
-   * @return {Number|null} The value of the setting
-   */
-  getFloat(name: string): number
-  /**
-   * Gets the requested value as an array. Returns null if the value does not exist or is not an array.
-   * @param {String} name The name of the setting that you want to value of
-   * @return {Array|null}
-   */
-  getArray<T = any>(name: string): Array<T>
-  /**
-   * Gets the requested value as a string. Returns null if the value does not exist or is not a string.
-   * @param {String} name The name of the setting that you want to value of
-   * @return {String|null}
-   */
-  getString(name: string): string
-  /**
    * Gets the requested value if it is not a Boolean.  Returns null if the value does not exist.
    * Throws an error if the requested value is a Boolean.
    *
@@ -91,6 +61,14 @@ export interface ICerebroConfig {
    * @return {!Boolean|*} The value of the setting
    */
   getValue<T = any>(name: string): T
+  /**
+   * Gets the requested value if it is not a Boolean.
+   * Throws an error if the requested value is a Boolean or is null.
+   *
+   * @param {String} name The name of the setting that you want to value of
+   * @return {!Boolean|*} The value of the setting
+   */
+  getAssertValue<T = any>(name: string): T
   /**
    * Serializes the object to send to the client.
    * Intended to be used on the server.
@@ -108,13 +86,11 @@ export interface ICerebroConfig {
    */
   getRawConfig(): Record<string, any>
   /**
-   * Returns the labels from the entries
+   * Returns an object in the form of `{ <setting_name>: <array of labels> }`.
    *
-   * @return {Object} The labels as an object just like getRawConfig,
-   * where each key is setting name and its value is an array of string labels.
-   * Entries with no labels are represented as an empty array (not undefined).
+   * For settings without labels, an empty array is assigned instead.
    */
-  getLabels(): Record<string, any>
+  getLabels(): Record<string, Array<string>>
   /**
    * Gets configuration categorized under a specific label.
    *


### PR DESCRIPTION
Type-specific getters turned out to be unnecessary as the YAML parser already does proper type conversion internally.

I was unable to justify keeping them as a result, and removed them to simplify the API.

A new method, `getAssertValue()`, was added to ensure a value exists, and throw if it does not.

Due to the removal of the type-specific getters, the package major version has been updated.